### PR TITLE
Dropped lodash as dependency. Added mocha as dev. Simplified interval logic.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/danielzurawski/systemcheck/issues"
   },
-  "dependencies": {
-    "lodash": "~2.4.1"
+  "devDependencies": {
+    "mocha": "^3.0.2"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -44,4 +44,5 @@ describe('systemcheck tests', function() {
         assert.equal(status['test'].status, 0);
         assert.equal(status['nyan'].status, 1);
     });
+
 });


### PR DESCRIPTION
I need to use this library and since I've seen zero updates I've thought some gardening would've been appreciated.

The `lodash` dependency was used for very trivial native operations that are already compatible with node 0.10 or higher: dropped.

The `mocha` dependency wasn't mentioned so that `npm test` was failing if `mocha` was not globally installed. Fixed now.

The interval callback was created every single time, even if it was reusing the same info each time.
This version creates such callback only once per setup, instead of per each interval call.
